### PR TITLE
Interop Notes

### DIFF
--- a/draft-ietf-emu-bootstrapped-tls.md
+++ b/draft-ietf-emu-bootstrapped-tls.md
@@ -174,7 +174,7 @@ and is created using the following values:
 external_identity = epskid
 context = "tls13-bsk"
 target_protocol = TLS1.3(0x0304)
-target_kdf = <as per RFC9528>
+target_kdf = <as per RFC9258>
 ~~~
 
 The ImportedIdentity context value MUST be "tls13-bsk". This informs the server that the mechanisms specified in this document for deriving the EPSK and executing the TLS handshake MUST be used. The EPSK and ImportedIdentity are used in the TLS handshake as specified in {{!RFC9258}}. Multiple ImportedIdentity values may be imported as per {{!RFC9258}} section 5.1. The target_kdf follows {{!RFC9258}} and aligns with the cipher suite hash algorithms advertised in the TLS 1.3 handshake between the device and the server.

--- a/draft-ietf-emu-bootstrapped-tls.md
+++ b/draft-ietf-emu-bootstrapped-tls.md
@@ -111,7 +111,7 @@ If future EAP methods are defined that support certificate provisioning, then TL
 
 # Bootstrap Key
 
-The mechanism for on-boarding of devices defined in this document relies on an elliptic curve (EC) bootstrap key (BSK). This BSK MUST be from a cryptosystem suitable for doing ECDSA. A bootstrapping client device has an associated EC BSK. The BSK may be static and baked into device firmware at manufacturing time, or may be dynamic and generated at on-boarding time by the device. The BSK public key MUST be encoded as the DER representation of an ASN.1 SEQUENCE SubjectPublicKeyInfo from {{!RFC5280}}. Note that the BSK public key encoding MUST include the ASN.1 AlgorithmIdentifier in addition to the subjectPublicKey. If the BSK public key can be shared in a trustworthy manner with a TLS server, a form of "entity authentication" (the step from which all subsequent authentication proceeds) can be obtained. 
+The mechanism for on-boarding of devices defined in this document relies on an elliptic curve (EC) bootstrap key (BSK). This BSK MUST be from a cryptosystem suitable for doing ECDSA. A bootstrapping client device has an associated EC BSK. The BSK may be static and baked into device firmware at manufacturing time, or may be dynamic and generated at on-boarding time by the device. The BSK public key MUST be encoded as the DER representation of an ASN.1 SEQUENCE SubjectPublicKeyInfo from {{!RFC5280}}. The subjectPublicKey MUST be the compressed format of the public key. Note that the BSK public key encoding MUST include the ASN.1 AlgorithmIdentifier in addition to the subjectPublicKey. If the BSK public key can be shared in a trustworthy manner with a TLS server, a form of "entity authentication" (the step from which all subsequent authentication proceeds) can be obtained. 
 
 The exact mechanism by which the server gains knowledge of the BSK public key is out of scope of this specification, but possible mechanisms include scanning a QR code to obtain a base64 encoding of the DER representation of the ASN.1 SubjectPublicKeyInfo or uploading of a Bill of Materials (BOM) which includes this information. More information on QR encoding is given in {{alignment-with-wi-fi-alliance-device-provisioning-profile}}. If the QR code is physically attached to the client device, or the BOM is associated with the device, the assumption is that the BSK public key obtained in this bootstrapping method belongs to the client. In this model, physical possession of the device implies legitimate ownership.
 
@@ -133,7 +133,7 @@ The TLS PSK handshake gives the client proof that the server knows the BSK publi
 
 ## External PSK Derivation
 
-An {{RFC9258}} EPSK is made up of the tuple of (Base Key, External Identity, Hash). The Base Key is the DER-encoded ASN.1 subjectPublicKeyInfo representation of the BSK public key. The External Identity is derived from the BSK public key using {{?RFC5869}} with the hash algorithm from the ciphersuite as follows:
+An {{RFC9258}} EPSK is made up of the tuple of (Base Key, External Identity, Hash). The Base Key is the DER-encoded ASN.1 subjectPublicKeyInfo representation of the BSK public key. Zero byte padding MUST NOT be added to the DER-encoded representation of the BSK public key. The External Identity is derived from the BSK public key using {{?RFC5869}} with the hash algorithm from the ciphersuite as follows:
 
 ~~~
 epskid = HKDF-Expand(HKDF-Extract(<>, Base Key),
@@ -258,6 +258,10 @@ This document adds the following to the "EAP Provisioning Identifiers" registry 
 NAI: tls-pok-dpp@teap.eap.arpa
 Method Type: TEAP
 Reference: THIS DOCUMENT
+
+# Implementation Considerations 
+
+Two key points are documented above, and are repeated here. The subjectPublicKey contained in the ASN.1 SEQUENCE SubjectPublicKeyInfo MUST be the compressed format of the public key. When deriving the External PSK from the BSK, zero byte padding MUST NOT be added to the DER-encoded representation of the BSK public key.
 
 # Security Considerations 
 


### PR DESCRIPTION
1.	Clarify that the public key should be compressed. 
2.	Clarify that no zero padding should be added to the public key with doing the PSK derivation.